### PR TITLE
Reparaciones:

### DIFF
--- a/PPAICU37/CambioEstado.cs
+++ b/PPAICU37/CambioEstado.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -18,21 +19,21 @@ namespace PPAICU37
             Motivos = new List<MotivoFueraServicio>();
         }
 
-        public static CambioEstado crear(DateTime fechaHoraInicio, List<MotivoFueraServicio> motivos, Estado estado)
+        public static CambioEstado crear(DateTime fechaHoraInicio, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentario, Estado estado)
         {
             var cambio = new CambioEstado
             {
                 FechaHoraInicio = fechaHoraInicio,
                 EstadoAsociado = estado
             };
-            if (motivos != null)
+            listaMotivosTipoComentario = listaMotivosTipoComentario ?? new List<Tuple<string, MotivoTipo>>();
+
+            MotivoFueraServicio motivo;
+            for (int i = 0; i < listaMotivosTipoComentario.Count; i++)
             {
-                foreach (var motivo in motivos)
-                {
-                    cambio.setMotivo(motivo);
-                }
+                motivo = new MotivoFueraServicio(listaMotivosTipoComentario[i].Item2, listaMotivosTipoComentario[i].Item1);
+                cambio.Motivos.Add(motivo);
             }
-            // Console.WriteLine($"DEBUG: CambioEstado creado para estado {estado?.NombreEstado} en {fechaHoraInicio}. Motivos: {motivos?.Count ?? 0}"); // Para depuración
             return cambio;
         }
 

--- a/PPAICU37/EstacionSismologica.cs
+++ b/PPAICU37/EstacionSismologica.cs
@@ -29,10 +29,11 @@ namespace PPAICU37
         //      }
         //  }
 
-        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<MotivoFueraServicio> motivos, Estado estadoFueraServicio, List<Sismografo> sismografos)
+        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentario, Estado estadoFueraServicio, List<Sismografo> sismografos)
         {
-            Sismografo sismografoAsociado = buscarIdSismografo(sismografos);
-            sismografoAsociado.ponerSismografoFueraDeServicio(fechaHora, motivos, estadoFueraServicio);         
+            Sismografo sismografoAsociado = buscarSismografo(sismografos);
+
+            sismografoAsociado.ponerSismografoFueraDeServicio(fechaHora, listaMotivosTipoComentario, estadoFueraServicio);         
 
         }
 
@@ -41,11 +42,16 @@ namespace PPAICU37
             return NombreEstacion;
         }
 
-        public Sismografo buscarIdSismografo(IEnumerable<Sismografo> sismografos)
+        public string buscarIdSismografo(IEnumerable<Sismografo> sismografos)
         {
             Sismografo sismografo = sismografos.FirstOrDefault(s => s.Estacion == this);
+            string idSismografo = sismografo.getidSismografo(); // Asegura que se obtenga el ID del sismógrafo asociado a la estación
             //    return sismografo.getidSismografo();
-            return sismografo;
+            return idSismografo;
+        }
+        public Sismografo buscarSismografo(IEnumerable<Sismografo> sismografos)
+        {
+            return sismografos.FirstOrDefault(s => s.Estacion == this);
         }
     }
 }

--- a/PPAICU37/MotivoTipo.cs
+++ b/PPAICU37/MotivoTipo.cs
@@ -15,5 +15,14 @@ namespace PPAICU37
         {
             return Descripcion;
         }
+        public MotivoTipo(int idTipo, string descripcion)
+        {
+            IdTipo = idTipo;
+            Descripcion = descripcion;
+        }
+        public MotivoTipo buscarMotivoTipo() 
+        { 
+            return this;
+        }
     }
 }

--- a/PPAICU37/OrdenDeInspeccion.cs
+++ b/PPAICU37/OrdenDeInspeccion.cs
@@ -36,8 +36,10 @@ namespace PPAICU37
 
         public string getInfoOrdenInspeccion(List<Sismografo> sismografos)
         {
-            Sismografo sismografo = EstacionSismologica.buscarIdSismografo(sismografos);
-            return $"Orden N°: {NumeroOrden}, Estado: {EstadoActual?.NombreEstado}, Sismógrafo: {sismografo?.IdentificadorSismografo}";
+            string nombreEstacion = EstacionSismologica.getNombre();
+            string idSismografo = EstacionSismologica.buscarIdSismografo(sismografos); // Asegura que se busque el sismógrafo asociado a la estación
+            DateTime? fechaHoraFinalizacion = this.FechaHoraFinalizacion;
+            return $"Orden N°: {NumeroOrden}, Estado: {EstadoActual?.NombreEstado}, Sismógrafo: {idSismografo}, FechaHoraFinalizacion {fechaHoraFinalizacion}";
         }
 
         public void registrarCierreOrden(DateTime fechaHoraCierre, string observacion, Estado estadoCerrado)
@@ -48,9 +50,9 @@ namespace PPAICU37
             // Console.WriteLine($"DEBUG: Orden {NumeroOrden} registrada como cerrada."); // Para depuración
         }
 
-        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<MotivoFueraServicio> motivos, Estado estadoFueraServicio, List<Sismografo> sismografos)
+        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentario, Estado estadoFueraServicio, List<Sismografo> sismografos)
         {
-            EstacionSismologica.ponerSismografoFueraDeServicio(fechaHora, motivos, estadoFueraServicio, sismografos);
+            EstacionSismologica.ponerSismografoFueraDeServicio(fechaHora, listaMotivosTipoComentario, estadoFueraServicio, sismografos);
         }
     }
 }

--- a/PPAICU37/PantallaCCRS.cs
+++ b/PPAICU37/PantallaCCRS.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -18,7 +19,7 @@ namespace PPAICU37
         }
 
         // actualizarMonitor() [cite: 1] - Adaptado para cargar datos
-        public void CargarDatos(string idSismo, string estado, DateTime fecha, List<MotivoFueraServicio> motivos, string observacion, IEnumerable<Sismografo> todosLosSismografos)
+        public void CargarDatos(string idSismo, string estado, DateTime fecha, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentario, string observacion, IEnumerable<Sismografo> todosLosSismografos)
         {
             // Asignar a los controles de la UI, ej:
             // identificacionSismografo (Label en diagrama) -> lblIdSismografo.Text = idSismografo;
@@ -35,11 +36,13 @@ namespace PPAICU37
             lblFechaHoraActual.Text = $"Fecha y Hora: {fecha:g}";
 
             lstMotivos.Items.Clear();
-            if (motivos != null && motivos.Any())
+            if (listaMotivosTipoComentario != null && listaMotivosTipoComentario.Any())
             {
-                foreach (var motivo in motivos)
+                foreach (var tupla in listaMotivosTipoComentario)
                 {
-                    lstMotivos.Items.Add($"Motivo: {motivo.Tipo.Descripcion} - Comentario: {motivo.Comentario}");
+                    string comentario = tupla.Item1;
+                    string descripcion = tupla.Item2.Descripcion;
+                    lstMotivos.Items.Add($"{descripcion}: {comentario}");
                 }
             }
             else

--- a/PPAICU37/PantallaCerrarOrden.Designer.cs
+++ b/PPAICU37/PantallaCerrarOrden.Designer.cs
@@ -70,7 +70,18 @@
             cmbTiposMotivo.Name = "cmbTiposMotivo";
             cmbTiposMotivo.Size = new Size(138, 28);
             cmbTiposMotivo.TabIndex = 2;
-            cmbTiposMotivo.SelectedIndexChanged += cmbTiposMotivo_SelectedIndexChanged;
+            cmbTiposMotivo.SelectedIndexChanged += seleccionarMotivo;
+            // 
+            // btnAgregarMotivo
+            // 
+            btnAgregarMotivo.Location = new Point(734, 515);
+            btnAgregarMotivo.Margin = new Padding(3, 4, 3, 4);
+            btnAgregarMotivo.Name = "btnAgregarMotivo";
+            btnAgregarMotivo.Size = new Size(86, 31);
+            btnAgregarMotivo.TabIndex = 5;
+            btnAgregarMotivo.Text = "Agregar";
+            btnAgregarMotivo.UseVisualStyleBackColor = true;
+            btnAgregarMotivo.Click += btnAgregarMotivo_Click;
             // 
             // txtComentario
             // 
@@ -89,17 +100,6 @@
             grillaMotivos.RowHeadersWidth = 51;
             grillaMotivos.Size = new Size(512, 200);
             grillaMotivos.TabIndex = 4;
-            // 
-            // btnAgregarMotivo
-            // 
-            btnAgregarMotivo.Location = new Point(734, 515);
-            btnAgregarMotivo.Margin = new Padding(3, 4, 3, 4);
-            btnAgregarMotivo.Name = "btnAgregarMotivo";
-            btnAgregarMotivo.Size = new Size(86, 31);
-            btnAgregarMotivo.TabIndex = 5;
-            btnAgregarMotivo.Text = "Agregar";
-            btnAgregarMotivo.UseVisualStyleBackColor = true;
-            btnAgregarMotivo.Click += btnAgregarMotivo_Click;
             // 
             // btnConfirmar
             // 

--- a/PPAICU37/PantallaMail.cs
+++ b/PPAICU37/PantallaMail.cs
@@ -20,7 +20,7 @@ namespace PPAICU37
             InitializeComponent();
         }
 
-        public void CargarDatos(string idSismografo, string nombreEstado, DateTime fechaHora, List<MotivoFueraServicio> motivos, string observacionCierre, string destinatarios)
+        public void CargarDatos(string idSismografo, string nombreEstado, DateTime fechaHora, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentarios, string observacionCierre, string destinatarios)
         {
             // Asignar a los controles de la UI, ej:
             // identificacionSismografo (Label en diagrama) -> lblIdSismografoMail.Text = idSismografo;
@@ -33,11 +33,13 @@ namespace PPAICU37
             lblFechaHoraActualMail.Text = $"Fecha y Hora: {fechaHora:g}";
 
             lstMotivosMail.Items.Clear();
-            if (motivos != null && motivos.Any())
+            if (listaMotivosTipoComentarios != null && listaMotivosTipoComentarios.Any())
             {
-                foreach (var motivo in motivos)
+                foreach (var tupla in listaMotivosTipoComentarios)
                 {
-                    lstMotivosMail.Items.Add($"Motivo: {motivo.Tipo.Descripcion} - Comentario: {motivo.Comentario}");
+                    string comentario = tupla.Item1;
+                    string descripcion = tupla.Item2.Descripcion;
+                    lstMotivosMail.Items.Add($"{descripcion}: {comentario}");
                 }
             }
             else

--- a/PPAICU37/Sismografo.cs
+++ b/PPAICU37/Sismografo.cs
@@ -12,7 +12,7 @@ namespace PPAICU37
         public string NroSerie { get; set; }
         public DateTime FechaAdquisicion { get; set; }
         public EstacionSismologica Estacion { get; set; }
-        public CambioEstado CambioEstadoActualSismografo { get; set; }
+    //    public CambioEstado CambioEstadoActualSismografo { get; set; }
         public List<CambioEstado> HistorialCambios { get; private set; }
 
         public Sismografo()
@@ -26,16 +26,16 @@ namespace PPAICU37
         }
 
         // Este método es invocado por OrdenDeInspeccion.ponerSismografoFueraDeServicio a través de Sismografo.cambiarEstado
-        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<MotivoFueraServicio> motivos, Estado estadoFueraServicio)
+        public void ponerSismografoFueraDeServicio(DateTime fechaHora, List<Tuple<string, MotivoTipo>> listaMotivosTipoComentario, Estado estadoFueraServicio)
         {
-            var cambioActualActivo = HistorialCambios.FirstOrDefault(h => h.esActual());
-            if (cambioActualActivo != null)
+            var cambioEstadoActualActivo = HistorialCambios.FirstOrDefault(h => h.esActual());
+            if (cambioEstadoActualActivo != null)
             {
-                cambioActualActivo.finalizar(fechaHora); // Finaliza el estado actual con la fecha y hora actual
+                cambioEstadoActualActivo.finalizar(fechaHora); // Finaliza el estado actual con la fecha y hora actual
             }
-            CambioEstado nuevoCambio = CambioEstado.crear(fechaHora, motivos, estadoFueraServicio); // Crea un nuevo cambio sin motivos
+            CambioEstado nuevoCambio = CambioEstado.crear(fechaHora, listaMotivosTipoComentario, estadoFueraServicio); // Crea un nuevo cambio sin motivos
             HistorialCambios.Add(nuevoCambio); // Agrega el nuevo cambio al historial
-            this.CambioEstadoActualSismografo = nuevoCambio; // Actualiza el estado actual del sismógrafo
+        //    this.CambioEstadoActualSismografo = nuevoCambio; //MODIFICAR
 
             // Console.WriteLine($"DEBUG: Sismógrafo {IdentificadorSismografo} marcado como fuera de servicio (método interno)."); // Para depuración
         }


### PR DESCRIPTION
- Sismografo no tiene cambioEstadoActual, ahora manejamos todo con el HistorialCambios general.

- PantallaMail ahora recibe la listaMotivosTipoComentarios
- Pantalla CCRS ahora recibe la listaMotivosTipoComentarios

- PantallaCerrarOrden, se arreglo el evento btnIniciarSesion. MostrarOrdenes tiene una logica distinta ahora, recibe las OrdenesFiltradas de verdad. El cargarTiposMotivosComboBox solo carga los TiposMotivos buscados. Cambio en la logica de btnAgregarMotivo. Cambio en toda la logica de mostrarMotivosAgregados. Cambio al selecciionarMotivo. Cambio de toda la logica completa de btnCerrarOrden. Cambio al reiniciar todo una vez se cierra la orden.

- En OrdenDeInspecciono mejora y finalizacion del metodo getInfoOrdenInspeccion.

- Agrego metodo buscarMotivoTipo en MotivoTipo.

- En EstacionSismologica agrego el metodo buscarSismografo para facilitar la busqueda directa del sismografo y no solo su id.

- ControladorCerrarOrden mejora en buscarOrdenInspeccion. Cambio en ordenarPorFecha. buscarTiposMotivos ahora es un metodo y no es buscarMotivos. agregarMotivoALista ahora agrega el MotivoTipo junto con el Comentario. tomarConfirmacionRegistrada devuelve un booleano y da inicio a cerrarOrden. Cambio completo en el metodo cerrarOrden.

- CambioEstado, modificamo el bucle al crear un nuevo cambio de estado.